### PR TITLE
fix: ContractLogicError is not raised from nethermind? response

### DIFF
--- a/src/bot/structs.py
+++ b/src/bot/structs.py
@@ -199,8 +199,13 @@ class Market:
 
     def get_user_emode(self, user: str, block: BlockIdentifier) -> bool | None:
         """Get user e-mode flag"""
-        with suppress(ContractLogicError):
-            return bool(self.lending_pool.functions.getUserEMode(user).call(block_identifier=block))
+        try:
+            with suppress(ContractLogicError):
+                return bool(self.lending_pool.functions.getUserEMode(user).call(block_identifier=block))
+        except ValueError as ex:
+            if "execution error" in str(ex):  # nethermind?
+                return None
+            raise
 
         return None
 


### PR DESCRIPTION
Receiving:
```json
{
    "id": 444,
    "jsonrpc": "2.0",
    "error": {
        "message": "VM execution error.",
        "code": 1
    }
}
```