### PR TITLE
feat(prometheus): new alerting rules

### DIFF
--- a/prometheus/zones_changes.rule
+++ b/prometheus/zones_changes.rule
@@ -1,6 +1,6 @@
 ---
 groups:
-  - name: aaveBot
+  - name: AAVEBot
     rules:
       - record: aave_bot_collaterals:total
         expr: sum (aave_bot_collaterals) by (pair, bin)
@@ -8,27 +8,31 @@ groups:
       - record: aave_bot_collaterals:risky
         expr: sum (aave_bot_collaterals{zone=~"C|D|liquidation"}) by (pair, bin)
 
-      - record: aave_bot_collaterals:risky:percent
-        expr: aave_bot_collaterals:risky / aave_bot_collaterals:total
+      - record: aave_bot_collaterals:percent
+        expr: aave_bot_collaterals / on (pair,bin) group_left aave_bot_collaterals:total
 
-      - alert: HighAmountCollateralsUnderRisk
-        expr: aave_bot_collaterals:risky:percent > 0.15
+      - alert: AAVEHighAmountCollateralsUnderRisk
+        expr: >
+          sum (aave_bot_collaterals:percent{zone=~"C|D|liquidation"}) by (pair,bin) > 0.15
+          and {pair="stETH-WETH"}
         for: 30m
         labels:
           severity: high
         annotations:
           summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
-          description: >-
+          description: &high-amount-under-risk-description >-
+            {{- $asset := .Labels.pair | reReplaceAll `(\w+)-(\w+)` "$1" -}}
+
             {{- if eq .Labels.pair "stETH-WETH" -}}
 
             {{- if eq .Labels.bin "1" -}}
-            > AAVE users with >=80% collaterals in stETH and >=80% debt in ETH
+            > AAVE users with >=80% collaterals in {{ $asset }} and >=80% debt in ETH
             {{- end -}}
             {{- if eq .Labels.bin "2" -}}
-            > AAVE users with stETH collateral and >=80% debt not in ETH
+            > AAVE users with {{ $asset }} collateral and >=80% debt not in ETH
             {{- end -}}
             {{- if eq .Labels.bin "3" -}}
-            > AAVE users with less significant stETH collateral amount
+            > AAVE users with less significant {{ $asset }} collateral amount
             {{- end -}}
 
             {{- end }}
@@ -36,26 +40,59 @@ groups:
             {{- if eq .Labels.pair "wstETH-WETH" -}}
 
             {{- if eq .Labels.bin "1" -}}
-            > Users with e-mode and with >=80% of collateral - wstETH, and >= 80% of debt - ETH
+            > Users with e-mode and with >=80% of collateral - {{ $asset }}, and >= 80% of debt - ETH
             {{- end -}}
             {{- if eq .Labels.bin "2" -}}
-            > Users without e-mode and with >=80% of collateral - wstETH, and >= 80% of debt - ETH
+            > Users without e-mode and with >=80% of collateral - {{ $asset }}, and >= 80% of debt - ETH
             {{- end -}}
             {{- if eq .Labels.bin "3" -}}
-            > Users with wstETH collateral and >=80% debt - not ETH
+            > Users with {{ $asset }} collateral and >=80% debt - not ETH
             {{- end -}}
             {{- if eq .Labels.bin "4" -}}
-            > All other AAVE users with wstETH collateral
+            > All other AAVE users with {{ $asset }} collateral
             {{- end -}}
 
             {{- end }}
 
-            It is {{ $value | humanizePercentage }} ({{
+            It is {{ .Value | humanizePercentage }} ({{
               with printf "aave_bot_collaterals:risky{pair=%q,bin=%q}" .Labels.pair .Labels.bin | query
-            }}{{ . | first | value | printf "%.1f" }}{{ end }}
-            {{ reReplaceAll `(\w+)-(\w+)` "$1" $labels.pair }})
-            of bin {{ .Labels.bin }} in risky zone!
+            }}{{ . | first | value | printf "%.1f" }}{{ end }} {{ $asset }})
+            of bin {{ .Labels.bin }} in risky zone, from which {{ with
+              printf "aave_bot_collaterals:percent{pair=%q,bin=%q,zone=~'C|D|liquidation'}" .Labels.pair .Labels.bin |
+              query | sortByLabel "zone" }}{{ range . }}{{ .Value | humanizePercentage }}{{
+              with printf "aave_bot_collaterals{pair=%q,bin=%q,zone=%q}" .Labels.pair .Labels.bin .Labels.zone | query
+                }}{{ $v := . | first | value | printf "%.1f" }}{{ if ne $v "0.0" }} ({{ $v }} {{ $asset }}){{ end }}{{
+                end }} in {{ .Labels.zone }}-category{{ if ne .Labels.zone "liquidation"
+                }}, {{ else }}{{ end }}{{ end }}{{ end }}
 
+      - alert: AAVEHighAmountCollateralsUnderRisk
+        expr: >
+          aave_bot_collaterals:percent{bin=~"2|3|4",pair=~"wstETH.+",zone="D"} > 0.10 and on (pair,bin,zone)
+          aave_bot_collaterals > 100
+        for: 30m
+        labels:
+          severity: high
+        annotations:
+          summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
+          description: *high-amount-under-risk-description
+
+      - alert: AAVEHighAmountCollateralsUnderRisk
+        expr: aave_bot_collaterals:percent{bin=~"2|3|4",pair!~"(w)?stETH.+",zone="D"} > 0.10
+        for: 30m
+        labels:
+          severity: high
+        annotations:
+          summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
+          description: *high-amount-under-risk-description
+
+      - alert: AAVEHighAmountCollateralsUnderRisk
+        expr: aave_bot_collaterals:percent{bin="1",pair!~"stETH.+",zone="D"} > 0.05
+        for: 30m
+        labels:
+          severity: high
+        annotations:
+          summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
+          description: *high-amount-under-risk-description
 
       - alert: AAVECollateralsLiquidation
         expr: aave_bot_collaterals{zone="liquidation"} > 0
@@ -94,5 +131,3 @@ groups:
             {{- end -}}
 
             {{- end }}
-
-# vim: set ts=2 sw=2 ft=yaml:

--- a/prometheus/zones_changes.test
+++ b/prometheus/zones_changes.test
@@ -3,30 +3,42 @@ rule_files:
   - "zones_changes.rule"
 evaluation_interval: 1m
 tests:
-  # HighAmountCollateralsUnderRisk
+  # AAVEHighAmountCollateralsUnderRisk
   - interval: 5m
     input_series:
       - series: aave_bot_collaterals{zone="OTHER", bin="1", pair="stETH-WETH"}
         values: 80+0x10
+      - series: aave_bot_collaterals{zone="C", bin="1", pair="stETH-WETH"}
+        values: 10+0x10
       - series: aave_bot_collaterals{zone="D", bin="1", pair="stETH-WETH"}
-        values: 20+0x10
+        values: 10+0x10
+      - series: aave_bot_collaterals{zone="liquidation", bin="1", pair="stETH-WETH"}
+        values: 0+0x10
 
       - series: aave_bot_collaterals{zone="OTHER", bin="2", pair="stETH-WETH"}
         values: 83+0x10
+      - series: aave_bot_collaterals{zone="C", bin="2", pair="stETH-WETH"}
+        values: 0+0x10
       - series: aave_bot_collaterals{zone="D", bin="2", pair="stETH-WETH"}
         values: 17+0x10
+      - series: aave_bot_collaterals{zone="liquidation", bin="2", pair="stETH-WETH"}
+        values: 0+0x10
 
       - series: aave_bot_collaterals{zone="OTHER", bin="3", pair="stETH-WETH"}
         values: 90+0x10
+      - series: aave_bot_collaterals{zone="C", bin="3", pair="stETH-WETH"}
+        values: 0+0x10
       - series: aave_bot_collaterals{zone="D", bin="3", pair="stETH-WETH"}
         values: 10+0x10
+      - series: aave_bot_collaterals{zone="liquidation", bin="3", pair="stETH-WETH"}
+        values: 0+0x10
     alert_rule_test:
       # no fire
       - eval_time: 5m
-        alertname: HighAmountCollateralsUnderRisk
+        alertname: AAVEHighAmountCollateralsUnderRisk
 
       - eval_time: 30m
-        alertname: HighAmountCollateralsUnderRisk
+        alertname: AAVEHighAmountCollateralsUnderRisk
         exp_alerts:
           # Bin 1
           - exp_labels:
@@ -38,7 +50,11 @@ tests:
               description: >-
                 > AAVE users with >=80% collaterals in stETH and >=80% debt in ETH
 
-                It is 20% (20.0 stETH) of bin 1 in risky zone!
+                It is 20% (20.0 stETH) of bin 1 in risky zone,
+                from which 10% (10.0 stETH) in C-category,
+                10% (10.0 stETH) in D-category,
+                0% in liquidation-category
+
           # Bin 2
           - exp_labels:
               pair: stETH-WETH
@@ -49,7 +65,74 @@ tests:
               description: >-
                 > AAVE users with stETH collateral and >=80% debt not in ETH
 
-                It is 17% (17.0 stETH) of bin 2 in risky zone!
+                It is 17% (17.0 stETH) of bin 2 in risky zone,
+                from which 0% in C-category,
+                17% (17.0 stETH) in D-category,
+                0% in liquidation-category
+
+  # AAVEHighAmountCollateralsUnderRisk
+  - interval: 5m
+    input_series:
+      - series: aave_bot_collaterals{zone="OTHER", bin="1", pair="wstETH-WETH"}
+        values: 94+0x10
+      - series: aave_bot_collaterals{zone="C", bin="1", pair="wstETH-WETH"}
+        values: 0+0x10
+      - series: aave_bot_collaterals{zone="D", bin="1", pair="wstETH-WETH"}
+        values: 6+0x10
+      - series: aave_bot_collaterals{zone="liquidation", bin="1", pair="wstETH-WETH"}
+        values: 0+0x10
+
+      - series: aave_bot_collaterals{zone="OTHER", bin="2", pair="wstETH-WETH"}
+        values: 880+0x10
+      - series: aave_bot_collaterals{zone="C", bin="2", pair="wstETH-WETH"}
+        values: 0+0x10
+      - series: aave_bot_collaterals{zone="D", bin="2", pair="wstETH-WETH"}
+        values: 120+0x10
+      - series: aave_bot_collaterals{zone="liquidation", bin="2", pair="wstETH-WETH"}
+        values: 0+0x10
+
+      - series: aave_bot_collaterals{zone="OTHER", bin="1", pair="wstETH-WETH-arb"}
+        values: 96+0x10
+      - series: aave_bot_collaterals{zone="D", bin="1", pair="wstETH-WETH-arb"}
+        values: 4+0x10
+
+    alert_rule_test:
+      # no fire
+      - eval_time: 5m
+        alertname: AAVEHighAmountCollateralsUnderRisk
+
+      - eval_time: 30m
+        alertname: AAVEHighAmountCollateralsUnderRisk
+        exp_alerts:
+          - exp_labels:
+              pair: wstETH-WETH
+              zone: D
+              bin: 1
+              severity: high
+            exp_annotations:
+              summary: High percent of AAVE wstETH-WETH bin 1 collaterals in dangerous zone 🔥
+              description: >-
+                > Users with e-mode and with >=80% of collateral - wstETH, and >= 80% of debt - ETH
+
+                It is 6% (6.0 wstETH) of bin 1 in risky zone,
+                from which 0% in C-category,
+                6% (6.0 wstETH) in D-category,
+                0% in liquidation-category
+
+          - exp_labels:
+              pair: wstETH-WETH
+              zone: D
+              bin: 2
+              severity: high
+            exp_annotations:
+              summary: High percent of AAVE wstETH-WETH bin 2 collaterals in dangerous zone 🔥
+              description: >-
+                > Users without e-mode and with >=80% of collateral - wstETH, and >= 80% of debt - ETH
+
+                It is 12% (120.0 wstETH) of bin 2 in risky zone,
+                from which 0% in C-category,
+                12% (120.0 wstETH) in D-category,
+                0% in liquidation-category
 
   # AAVECollateralsLiquidation
   - interval: 5m


### PR DESCRIPTION
New alerting conditions:
- AAVE v2 (stETH) - no changes
- for bins 2,3,4 of v3:
    - \> 10% in D-category and > 100 wstETH for wstETH pairs
- for bin 1 of v3:
    - \>5% in D-category