### PR TITLE
feat(prometheus): use inline_fields annotation to build a table

### DIFF
--- a/prometheus/zones_changes.rule
+++ b/prometheus/zones_changes.rule
@@ -53,17 +53,29 @@ groups:
             {{- end -}}
 
             {{- end }}
+          inline_fields: &high-amount-under-risk-table |-
+            {{- $amount :=
+              printf "aave_bot_collaterals:risky{pair=%q,bin=%q}" .Labels.pair .Labels.bin | query |
+              first | value | printf "%.1f" -}}
 
-            It is {{ .Value | humanizePercentage }} ({{
-              with printf "aave_bot_collaterals:risky{pair=%q,bin=%q}" .Labels.pair .Labels.bin | query
-            }}{{ . | first | value | printf "%.1f" }}{{ end }} {{ $asset }})
-            of bin {{ .Labels.bin }} in risky zone, from which {{ with
+            {{- $asset := .Labels.pair | reReplaceAll `(\w+)-(\w+)` "$1" -}}
+
+            - **📊 Share**
+            - **🏦 Amount**
+            -
+
+            - {{ .Value | humanizePercentage }} in C+D+liquidation
+            - {{ $amount }} {{ $asset }}
+            -
+            {{ with
               printf "aave_bot_collaterals:percent{pair=%q,bin=%q,zone=~'C|D|liquidation'}" .Labels.pair .Labels.bin |
-              query | sortByLabel "zone" }}{{ range . }}{{ .Value | humanizePercentage }}{{
-              with printf "aave_bot_collaterals{pair=%q,bin=%q,zone=%q}" .Labels.pair .Labels.bin .Labels.zone | query
-                }}{{ $v := . | first | value | printf "%.1f" }}{{ if ne $v "0.0" }} ({{ $v }} {{ $asset }}){{ end }}{{
-                end }} in {{ .Labels.zone }}-category{{ if ne .Labels.zone "liquidation"
-                }}, {{ else }}{{ end }}{{ end }}{{ end }}
+              query | sortByLabel "zone" }}{{ range .
+            }}
+            - {{ .Value | humanizePercentage }} in {{ .Labels.zone }}
+            - {{ with printf "aave_bot_collaterals{pair=%q,bin=%q,zone=%q}" .Labels.pair .Labels.bin .Labels.zone |
+            query }}{{ $v := . | first | value | printf "%.1f" }}{{ $v }} {{ $asset }}{{ end }}
+            -
+            {{ end }}{{ end }}
 
       - alert: AAVEHighAmountCollateralsUnderRisk
         expr: >
@@ -75,6 +87,7 @@ groups:
         annotations:
           summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
           description: *high-amount-under-risk-description
+          inline_fields: *high-amount-under-risk-table
 
       - alert: AAVEHighAmountCollateralsUnderRisk
         expr: aave_bot_collaterals:percent{bin=~"2|3|4",pair!~"(w)?stETH.+",zone="D"} > 0.10
@@ -84,6 +97,7 @@ groups:
         annotations:
           summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
           description: *high-amount-under-risk-description
+          inline_fields: *high-amount-under-risk-table
 
       - alert: AAVEHighAmountCollateralsUnderRisk
         expr: aave_bot_collaterals:percent{bin="1",pair!~"stETH.+",zone="D"} > 0.05
@@ -93,6 +107,7 @@ groups:
         annotations:
           summary: High percent of AAVE {{ .Labels.pair }} bin {{ .Labels.bin }} collaterals in dangerous zone 🔥
           description: *high-amount-under-risk-description
+          inline_fields: *high-amount-under-risk-table
 
       - alert: AAVECollateralsLiquidation
         expr: aave_bot_collaterals{zone="liquidation"} > 0

--- a/prometheus/zones_changes.test
+++ b/prometheus/zones_changes.test
@@ -49,11 +49,26 @@ tests:
               summary: High percent of AAVE stETH-WETH bin 1 collaterals in dangerous zone 🔥
               description: >-
                 > AAVE users with >=80% collaterals in stETH and >=80% debt in ETH
+              inline_fields: |
+                - **📊 Share**
+                - **🏦 Amount**
+                -
 
-                It is 20% (20.0 stETH) of bin 1 in risky zone,
-                from which 10% (10.0 stETH) in C-category,
-                10% (10.0 stETH) in D-category,
-                0% in liquidation-category
+                - 20% in C+D+liquidation
+                - 20.0 stETH
+                -
+
+                - 10% in C
+                - 10.0 stETH
+                -
+
+                - 10% in D
+                - 10.0 stETH
+                -
+
+                - 0% in liquidation
+                - 0.0 stETH
+                -
 
           # Bin 2
           - exp_labels:
@@ -64,11 +79,26 @@ tests:
               summary: High percent of AAVE stETH-WETH bin 2 collaterals in dangerous zone 🔥
               description: >-
                 > AAVE users with stETH collateral and >=80% debt not in ETH
+              inline_fields: |
+                - **📊 Share**
+                - **🏦 Amount**
+                -
 
-                It is 17% (17.0 stETH) of bin 2 in risky zone,
-                from which 0% in C-category,
-                17% (17.0 stETH) in D-category,
-                0% in liquidation-category
+                - 17% in C+D+liquidation
+                - 17.0 stETH
+                -
+
+                - 0% in C
+                - 0.0 stETH
+                -
+
+                - 17% in D
+                - 17.0 stETH
+                -
+
+                - 0% in liquidation
+                - 0.0 stETH
+                -
 
   # AAVEHighAmountCollateralsUnderRisk
   - interval: 5m
@@ -113,11 +143,26 @@ tests:
               summary: High percent of AAVE wstETH-WETH bin 1 collaterals in dangerous zone 🔥
               description: >-
                 > Users with e-mode and with >=80% of collateral - wstETH, and >= 80% of debt - ETH
+              inline_fields: |
+                - **📊 Share**
+                - **🏦 Amount**
+                -
 
-                It is 6% (6.0 wstETH) of bin 1 in risky zone,
-                from which 0% in C-category,
-                6% (6.0 wstETH) in D-category,
-                0% in liquidation-category
+                - 6% in C+D+liquidation
+                - 6.0 wstETH
+                -
+
+                - 0% in C
+                - 0.0 wstETH
+                -
+
+                - 6% in D
+                - 6.0 wstETH
+                -
+
+                - 0% in liquidation
+                - 0.0 wstETH
+                -
 
           - exp_labels:
               pair: wstETH-WETH
@@ -128,11 +173,26 @@ tests:
               summary: High percent of AAVE wstETH-WETH bin 2 collaterals in dangerous zone 🔥
               description: >-
                 > Users without e-mode and with >=80% of collateral - wstETH, and >= 80% of debt - ETH
+              inline_fields: |
+                - **📊 Share**
+                - **🏦 Amount**
+                -
 
-                It is 12% (120.0 wstETH) of bin 2 in risky zone,
-                from which 0% in C-category,
-                12% (120.0 wstETH) in D-category,
-                0% in liquidation-category
+                - 12% in C+D+liquidation
+                - 120.0 wstETH
+                -
+
+                - 0% in C
+                - 0.0 wstETH
+                -
+
+                - 12% in D
+                - 120.0 wstETH
+                -
+
+                - 0% in liquidation
+                - 0.0 wstETH
+                -
 
   # AAVECollateralsLiquidation
   - interval: 5m


### PR DESCRIPTION
Construct a table using `inline_fields` feature of `alertmanager-discord`. Every third field of the list was kept empty consciously to make the fields construct the table. The fields will be filled with the collateral USD value in the feature releases.  